### PR TITLE
#36 Fix missing path in URL Builder

### DIFF
--- a/src/app/pages/url-builder/components/url-builder/url-builder.component.ts
+++ b/src/app/pages/url-builder/components/url-builder/url-builder.component.ts
@@ -76,7 +76,7 @@ export class UrlBuilderComponent {
 
             let model: LinkBuilderModel = {
                 protocol: urlObj.protocol.startsWith('https') ? 'https' : 'http',
-                domain: urlObj.hostname,
+                domain: urlObj.hostname + urlObj.pathname,
                 queryStrings: [],
                 fragment: urlObj.hash
             };


### PR DESCRIPTION
This PR fixes an issue with missing path after redirect from URL Analyzer.
See #36 for more details.